### PR TITLE
Quick fix for RPS L2's top-k and top-k on training set

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ Influenciae is a Python toolkit dedicated to computing influence values for the 
 
 We propose some hands-on tutorials to get familiar with the library and it's API:
 
-- [Getting Started](https://drive.google.com/file/d/145Gi4gCYTKlRVJjsty5cPkdMGNJoNDws/view?usp=share_link) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://drive.google.com/file/d/145Gi4gCYTKlRVJjsty5cPkdMGNJoNDws/view?usp=share_link) </sub>
-- Benchmarking with Mislabeled sample detection (**WIP**)
-- Using the first order influence calculator (**WIP**)
-- Using the second order influence calculator (**WIP**)
-- Using TracIn (**WIP**)
-- Using Representer Point Selection - L2 (RPS_L2) (**WIP**)
-- Using Representer Point Selection - Local Jacobian Expansion (RPS_LJE) (**WIP**)
+- [**Getting Started**](https://colab.research.google.com/drive/1vQ6seX6KOr48zx4nLELoy9j1X4jzQv1p?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1vQ6seX6KOr48zx4nLELoy9j1X4jzQv1p?usp=sharing) </sub>
+- [**Benchmarking with Mislabeled sample detection**](https://colab.research.google.com/drive/1_5-RC_YBHptVCElBbjxWfWQ1LMU20vOp?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1_5-RC_YBHptVCElBbjxWfWQ1LMU20vOp?usp=sharing) </sub>
+- [**Using the first order influence calculator**](https://colab.research.google.com/drive/1WlYcQNu5obhVjhonN2QYi8ybKyZJl4iY?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1WlYcQNu5obhVjhonN2QYi8ybKyZJl4iY?usp=sharing) </sub>
+- [**Using the second order influence calculator**](https://colab.research.google.com/drive/1qNvKiU3-aZWhRA0rxS6X3ebeNkoznJJe?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1qNvKiU3-aZWhRA0rxS6X3ebeNkoznJJe?usp=sharing) </sub>
+- [**Using TracIn**](https://colab.research.google.com/drive/1E94cGF46SUQXcCTNwQ4VGSjXEKm7g21c?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1E94cGF46SUQXcCTNwQ4VGSjXEKm7g21c?usp=sharing) </sub>
+- [**Using Representer Point Selection - L2 (RPS_L2)**](https://colab.research.google.com/drive/17W5s30LbxABbDd8hbdwYE56abyWjSC4u?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/17W5s30LbxABbDd8hbdwYE56abyWjSC4u?usp=sharing) </sub>
+- [**Using Representer Point Selection - Local Jacobian Expansion (RPS_LJE)**](https://colab.research.google.com/drive/14e7wwFRQJhY-huVYmJ7ri355kfLJgAPA?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/14e7wwFRQJhY-huVYmJ7ri355kfLJgAPA?usp=sharing) </sub>
 
 ## 🚀 Quick Start
 
-Influenciae requires a version of python higher than 3.6 and several libraries, including Tensorflow and Numpy. Installation can be done using Pypi:
+Influenciae requires a version of python 3.7 or higher and several libraries, including Tensorflow and Numpy. Installation can be done using Pypi:
 
 ```python
 pip install influenciae
@@ -68,7 +68,7 @@ data_and_influence_dataset = influence_calculator.compute_influence_values(train
 # dataset is too large
 ```
 
-This is also explained more in depth in the [Getting Started tutotial](https://drive.google.com/file/d/145Gi4gCYTKlRVJjsty5cPkdMGNJoNDws/view?usp=share_link) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://drive.google.com/file/d/145Gi4gCYTKlRVJjsty5cPkdMGNJoNDws/view?usp=share_link) </sub>
+This is also explained more in depth in the [Getting Started tutotial](https://colab.research.google.com/drive/1vQ6seX6KOr48zx4nLELoy9j1X4jzQv1p?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1vQ6seX6KOr48zx4nLELoy9j1X4jzQv1p?usp=sharing) </sub>
 
 ### Explaining neural networks through their training data
 
@@ -90,7 +90,7 @@ data_and_influence_dataset = influence_calculator.estimate_influence_values_in_b
 # dataset is too large
 ```
 
-This is also explained more in depth in the [Getting Started tutorial](https://drive.google.com/file/d/145Gi4gCYTKlRVJjsty5cPkdMGNJoNDws/view?usp=share_link) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://drive.google.com/file/d/145Gi4gCYTKlRVJjsty5cPkdMGNJoNDws/view?usp=share_link) </sub>
+This is also explained more in depth in the [Getting Started tutorial](https://colab.research.google.com/drive/1vQ6seX6KOr48zx4nLELoy9j1X4jzQv1p?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1vQ6seX6KOr48zx4nLELoy9j1X4jzQv1p?usp=sharing) </sub>
 
 ### Determining the influence of groups of samples
 
@@ -130,15 +130,15 @@ data_and_influence_dataset = influence_calculator.estimate_influence_values_grou
 
 All the influence calculation methods work on Tensorflow models trained for any sort of task and on any type of data. Visualization functionality is implemented for image datasets only (for the moment).
 
-| **Influence Method**                                    | Source                                    |                                      Tutorial                                      |
-|:--------------------------------------------------------| :---------------------------------------- |:----------------------------------------------------------------------------------:|
-| Influence Functions                                     | [Paper](https://arxiv.org/abs/1703.04730)  |                                        WIP                                         |
-| RelatIF                                                 | [Paper](https://arxiv.org/pdf/2003.11630.pdf)  |                                        WIP                                         |
-| Influence Functions  (first order, groups)              | [Paper](https://arxiv.org/abs/1905.13289)  |                                        WIP                                         |
-| Influence Functions  (second order, groups)             | [Paper](https://arxiv.org/abs/1911.00418)  | WIP  |
-| Representer Point Selection  (L2)                       | [Paper](https://arxiv.org/abs/1811.09720)  | WIP  |
-| Representer Point Selection  (Local Jacobian Expansion) | [Paper](https://proceedings.neurips.cc/paper/2021/file/c460dc0f18fc309ac07306a4a55d2fd6-Paper.pdf)  | WIP  |
-| Trac-In                                                 | [Paper](https://arxiv.org/abs/2002.08484)  | WIP  |
+| **Influence Method**                                    | Source                                    |                                                                               Tutorial                                                                               |
+|:--------------------------------------------------------| :---------------------------------------- |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+| Influence Functions                                     | [Paper](https://arxiv.org/abs/1703.04730)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1WlYcQNu5obhVjhonN2QYi8ybKyZJl4iY?usp=sharing)  |
+| RelatIF                                                 | [Paper](https://arxiv.org/pdf/2003.11630.pdf)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1WlYcQNu5obhVjhonN2QYi8ybKyZJl4iY?usp=sharing)  |
+| Influence Functions  (first order, groups)              | [Paper](https://arxiv.org/abs/1905.13289)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1WlYcQNu5obhVjhonN2QYi8ybKyZJl4iY?usp=sharing)  |
+| Influence Functions  (second order, groups)             | [Paper](https://arxiv.org/abs/1911.00418)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1qNvKiU3-aZWhRA0rxS6X3ebeNkoznJJe?usp=sharing)  |
+| Representer Point Selection  (L2)                       | [Paper](https://arxiv.org/abs/1811.09720)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/17W5s30LbxABbDd8hbdwYE56abyWjSC4u?usp=sharing)  |
+| Representer Point Selection  (Local Jacobian Expansion) | [Paper](https://proceedings.neurips.cc/paper/2021/file/c460dc0f18fc309ac07306a4a55d2fd6-Paper.pdf)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/14e7wwFRQJhY-huVYmJ7ri355kfLJgAPA?usp=sharing)  |
+| Trac-In                                                 | [Paper](https://arxiv.org/abs/2002.08484)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1E94cGF46SUQXcCTNwQ4VGSjXEKm7g21c?usp=sharing)  |
 
 ## 👀 See Also
 
@@ -163,7 +163,7 @@ This project received funding from the French ”Investing for the Future – PI
 
 ## 👨‍🎓 Creators
 
-This library was first created as a research tool by [Agustin-Martin PICARD](mailto:agustin-martin.picard@irt-saintexupery.com) in the context of the DEEL project with the help of [David Vigouroux](mailto:david.vigouroux@irt-saintexupery.com) and [Thomas FEL](http://thomasfel.fr). Later on, [Lucas Hervier](https://github.com/lucashervier) joined the team to transform the code base as a practical user-(almost)-friendly and efficient tool.
+This library was first created as a research tool by [Agustin Martin PICARD](mailto:agustin-martin.picard@irt-saintexupery.com) in the context of the DEEL project with the help of [David Vigouroux](mailto:david.vigouroux@irt-saintexupery.com) and [Thomas FEL](http://thomasfel.fr). Later on, [Lucas Hervier](https://github.com/lucashervier) joined the team to transform the code base as a practical user-(almost)-friendly and efficient tool.
 
 ## 📝 License
 

--- a/deel/influenciae/benchmark/base_benchmark.py
+++ b/deel/influenciae/benchmark/base_benchmark.py
@@ -433,7 +433,7 @@ class MislabelingDetectorEvaluator:
         dirname = os.path.dirname(path_to_save)
         if not os.path.exists(dirname):
             os.makedirs(dirname)
-        np.save(path_to_save, (curves, mean_curve, roc), allow_pickle=True)
+        np.save(path_to_save, np.array((curves, mean_curve, roc), dtype=object), allow_pickle=True)
 
 
 class ModelsSaver(tf.keras.callbacks.Callback):
@@ -492,4 +492,3 @@ class ModelsSaver(tf.keras.callbacks.Callback):
                 np.save(f"{self.saving_path}/learning_rates", np.array(self.learning_rates), allow_pickle=True)
                 with open(f"{self.saving_path}/logs.json", "w", encoding='utf8') as f:
                     json.dump(logs, f)
-

--- a/deel/influenciae/benchmark/base_benchmark.py
+++ b/deel/influenciae/benchmark/base_benchmark.py
@@ -301,7 +301,7 @@ class MislabelingDetectorEvaluator:
         for i, c in enumerate(curve):
             tf.summary.scalar(experiment_name, c, i)
 
-    def __build(self, curves: List[np.ndarray]) -> Tuple[np.ndarray, np.ndarray, np.float]:
+    def __build(self, curves: List[np.ndarray]) -> Tuple[np.ndarray, np.ndarray, float]:
         """
         Formats the curves, computes the mean curve and the ROC.
 
@@ -321,7 +321,7 @@ class MislabelingDetectorEvaluator:
         return curves, mean_curve, roc
 
     @staticmethod
-    def _compute_roc(curve: np.array) -> np.float:
+    def _compute_roc(curve: np.array) -> float:
         """
         Computes the ROC value of the curve.
 

--- a/deel/influenciae/benchmark/base_benchmark.py
+++ b/deel/influenciae/benchmark/base_benchmark.py
@@ -415,7 +415,7 @@ class MislabelingDetectorEvaluator:
         return noisy_dataset, noise_indexes
 
     @staticmethod
-    def __save(path_to_save: str, curves: np.array, mean_curve: np.array, roc: np.float) -> None:
+    def __save(path_to_save: str, curves: np.array, mean_curve: np.array, roc: float) -> None:
         """
         Saves an evaluation's results to the disk.
 

--- a/deel/influenciae/benchmark/cifar10_benchmark.py
+++ b/deel/influenciae/benchmark/cifar10_benchmark.py
@@ -247,6 +247,8 @@ class Cifar10MislabelingDetectorEvaluator(MislabelingDetectorEvaluator):
         An integer with the size of the batches on which to train the model.
     test_batch_size
         An integer with the size of the batches on which to perform the validation.
+    influence_batch_size
+        An integer with the size of the batches for performing the different operations
     epochs_to_save
         A list of integers for the eventual saving of the model's checkpoints and training information.
         Useful for computing influence-related quantities using TracIn.

--- a/deel/influenciae/common/base_influence.py
+++ b/deel/influenciae/common/base_influence.py
@@ -143,6 +143,8 @@ class SelfInfluenceCalculator:
 
         for batch in train_set:
             influence_values = self._compute_influence_value_from_batch(batch)
+            if len(influence_values.shape) == 1:
+                influence_values = tf.expand_dims(influence_values, axis=-1)
             batch_sorted_dict.add_all(tf.expand_dims(batch[0], axis=0), tf.transpose(influence_values))
 
         best_samples, best_values = batch_sorted_dict.get()

--- a/deel/influenciae/rps/rps_l2.py
+++ b/deel/influenciae/rps/rps_l2.py
@@ -172,8 +172,8 @@ class RepresenterPointL2(BaseInfluenceCalculator):
         if len(alpha.shape) == 1 or (len(alpha.shape) == 2 and alpha.shape[1] == 1):
             influence_values = alpha * tf.matmul(feature_maps_train, feature_maps_test, transpose_b=True)
         else:
-            influence_values = tf.gather(alpha, tf.argmax(labels_test, axis=1), axis=1, batch_dims=1) * \
-                           tf.matmul(feature_maps_train, feature_maps_test, transpose_b=True)
+            influence_values = tf.gather(alpha, labels_test, axis=1, batch_dims=1) * \
+                               tf.matmul(feature_maps_train, feature_maps_test, transpose_b=True)
         influence_values = tf.transpose(influence_values)
 
         return influence_values

--- a/docs/api/benchmarks.md
+++ b/docs/api/benchmarks.md
@@ -19,7 +19,7 @@ benchmarking, and an implementation on the popular CIFAR10 image-classification 
 
 ## Notebooks
 
-- **WIP**
+- [**Benchmarking with Mislabeled sample detection**](https://colab.research.google.com/drive/1_5-RC_YBHptVCElBbjxWfWQ1LMU20vOp?usp=sharing)
 
 {{deel.influenciae.benchmark.cifar10_benchmark.Cifar10TrainingProcedure}}
 

--- a/docs/api/influence/first_order_influence_calculator.md
+++ b/docs/api/influence/first_order_influence_calculator.md
@@ -29,6 +29,6 @@ to `True`.
 ## Notebooks
 
 - [**Getting started**](https://drive.google.com/file/d/145Gi4gCYTKlRVJjsty5cPkdMGNJoNDws/view?usp=share_link)
-- Using First order influence calculator **WIP**
+- [**Using the first order influence calculator**](https://colab.research.google.com/drive/1WlYcQNu5obhVjhonN2QYi8ybKyZJl4iY?usp=sharing)
 
 {{deel.influenciae.influence.first_order_influence_calculator.FirstOrderInfluenceCalculator}}

--- a/docs/api/influence/second_order_influence_calculator.md
+++ b/docs/api/influence/second_order_influence_calculator.md
@@ -20,6 +20,6 @@ computations are carried out by objects from the class `InverseHessianVectorProd
 
 ## Notebooks
 
-- **WIP**
+- [**Using the second order influence calculator**](https://colab.research.google.com/drive/1qNvKiU3-aZWhRA0rxS6X3ebeNkoznJJe?usp=sharing)
 
 {{deel.influenciae.influence.second_order_influence_calculator.SecondOrderInfluenceCalculator}}

--- a/docs/api/representer_point_selection/rps_l2.md
+++ b/docs/api/representer_point_selection/rps_l2.md
@@ -27,7 +27,7 @@ a certain efficiency once the surrogate model has been learned.
 
 ## Notebooks
 
-- **WIP**
+- [**Using Representer Point Selection - L2 (RPS_L2)**](https://colab.research.google.com/drive/17W5s30LbxABbDd8hbdwYE56abyWjSC4u?usp=sharing)
 
 
 {{deel.influenciae.rps.rps_l2.RepresenterPointL2}}

--- a/docs/api/representer_point_selection/rps_lje.md
+++ b/docs/api/representer_point_selection/rps_lje.md
@@ -23,6 +23,6 @@ so efficiently.
 
 ## Notebooks
 
-- **WIP**
+- [**Using Representer Point Selection - Local Jacobian Expansion (RPS_LJE)**](https://colab.research.google.com/drive/14e7wwFRQJhY-huVYmJ7ri355kfLJgAPA?usp=sharing)
 
 {{deel.influenciae.rps.rps_lje.RepresenterPointLJE}}

--- a/docs/api/tracin.md
+++ b/docs/api/tracin.md
@@ -21,6 +21,6 @@ but does require to provide some of the model's checkpoints and the learning rat
 
 ## Notebooks
 
-- **WIP**
+- [**Using TracIn**](https://colab.research.google.com/drive/1E94cGF46SUQXcCTNwQ4VGSjXEKm7g21c?usp=sharing)
 
 {{deel.influenciae.trac_in.tracin.TracIn}}

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,20 +30,20 @@ Influenciae is a Python toolkit dedicated to computing influence values for the 
 
 We propose some hands-on tutorials to get familiar with the library and it's API:
 
-- [**Getting Started**](https://drive.google.com/file/d/145Gi4gCYTKlRVJjsty5cPkdMGNJoNDws/view?usp=share_link) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://drive.google.com/file/d/145Gi4gCYTKlRVJjsty5cPkdMGNJoNDws/view?usp=share_link) </sub>
-- Benchmarking with Mislabeled sample detection (**WIP**)
-- Using the first order influence calculator (**WIP**)
-- Using the second order influence calculator (**WIP**)
-- Using TracIn (**WIP**)
-- Using Representer Point Selection - L2 (RPS_L2) (**WIP**)
-- Using Representer Point Selection - Local Jacobian Expansion (RPS_LJE) (**WIP**)
+- [**Getting Started**](https://colab.research.google.com/drive/1vQ6seX6KOr48zx4nLELoy9j1X4jzQv1p?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1vQ6seX6KOr48zx4nLELoy9j1X4jzQv1p?usp=sharing) </sub>
+- [**Benchmarking with Mislabeled sample detection**](https://colab.research.google.com/drive/1_5-RC_YBHptVCElBbjxWfWQ1LMU20vOp?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1_5-RC_YBHptVCElBbjxWfWQ1LMU20vOp?usp=sharing) </sub>
+- [**Using the first order influence calculator**](https://colab.research.google.com/drive/1WlYcQNu5obhVjhonN2QYi8ybKyZJl4iY?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1WlYcQNu5obhVjhonN2QYi8ybKyZJl4iY?usp=sharing) </sub>
+- [**Using the second order influence calculator**](https://colab.research.google.com/drive/1qNvKiU3-aZWhRA0rxS6X3ebeNkoznJJe?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1qNvKiU3-aZWhRA0rxS6X3ebeNkoznJJe?usp=sharing) </sub>
+- [**Using TracIn**](https://colab.research.google.com/drive/1E94cGF46SUQXcCTNwQ4VGSjXEKm7g21c?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1E94cGF46SUQXcCTNwQ4VGSjXEKm7g21c?usp=sharing) </sub>
+- [**Using Representer Point Selection - L2 (RPS_L2)**](https://colab.research.google.com/drive/17W5s30LbxABbDd8hbdwYE56abyWjSC4u?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/17W5s30LbxABbDd8hbdwYE56abyWjSC4u?usp=sharing) </sub>
+- [**Using Representer Point Selection - Local Jacobian Expansion (RPS_LJE)**](https://colab.research.google.com/drive/14e7wwFRQJhY-huVYmJ7ri355kfLJgAPA?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/14e7wwFRQJhY-huVYmJ7ri355kfLJgAPA?usp=sharing) </sub>
 
 ## 🚀 Quick Start
 
-Influenciae requires a version of python higher than 3.6 and several libraries, including Tensorflow and Numpy. Installation can be done using Pypi:
+Influenciae requires a version of python 3.7 or higher and several libraries, including Tensorflow and Numpy. Installation can be done using Pypi:
 
 ```python
-pip install deel-influenciae
+pip install influenciae
 ```
 
 Once Influenciae is installed, there are two major applications for the different modules (that all follow the same API).
@@ -68,7 +68,7 @@ data_and_influence_dataset = influence_calculator.compute_influence_values(train
 # dataset is too large
 ```
 
-This is also explained more in depth in the [Getting Started tutotial](https://drive.google.com/file/d/145Gi4gCYTKlRVJjsty5cPkdMGNJoNDws/view?usp=share_link) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://drive.google.com/file/d/145Gi4gCYTKlRVJjsty5cPkdMGNJoNDws/view?usp=share_link) </sub>
+This is also explained more in depth in the [Getting Started tutotial](https://colab.research.google.com/drive/1vQ6seX6KOr48zx4nLELoy9j1X4jzQv1p?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1vQ6seX6KOr48zx4nLELoy9j1X4jzQv1p?usp=sharing) </sub>
 
 ### Explaining neural networks through their training data
 
@@ -90,7 +90,7 @@ data_and_influence_dataset = influence_calculator.estimate_influence_values_in_b
 # dataset is too large
 ```
 
-This is also explained more in depth in the [Getting Started tutorial](https://drive.google.com/file/d/145Gi4gCYTKlRVJjsty5cPkdMGNJoNDws/view?usp=share_link) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://drive.google.com/file/d/145Gi4gCYTKlRVJjsty5cPkdMGNJoNDws/view?usp=share_link) </sub>
+This is also explained more in depth in the [Getting Started tutorial](https://colab.research.google.com/drive/1vQ6seX6KOr48zx4nLELoy9j1X4jzQv1p?usp=sharing) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1vQ6seX6KOr48zx4nLELoy9j1X4jzQv1p?usp=sharing) </sub>
 
 ### Determining the influence of groups of samples
 
@@ -130,15 +130,15 @@ data_and_influence_dataset = influence_calculator.estimate_influence_values_grou
 
 All the influence calculation methods work on Tensorflow models trained for any sort of task and on any type of data. Visualization functionality is implemented for image datasets only (for the moment).
 
-| **Influence Method**                                    | Source                                    |                                      Tutorial                                      |
-|:--------------------------------------------------------| :---------------------------------------- |:----------------------------------------------------------------------------------:|
-| Influence Functions                                     | [Paper](https://arxiv.org/abs/1703.04730)  |                                        WIP                                         |
-| RelatIF                                                 | [Paper](https://arxiv.org/pdf/2003.11630.pdf)  |                                        WIP                                         |
-| Influence Functions  (first order, groups)              | [Paper](https://arxiv.org/abs/1905.13289)  |                                        WIP                                         |
-| Influence Functions  (second order, groups)             | [Paper](https://arxiv.org/abs/1911.00418)  | WIP  |
-| Representer Point Selection  (L2)                       | [Paper](https://arxiv.org/abs/1811.09720)  | WIP  |
-| Representer Point Selection  (Local Jacobian Expansion) | [Paper](https://proceedings.neurips.cc/paper/2021/file/c460dc0f18fc309ac07306a4a55d2fd6-Paper.pdf)  | WIP  |
-| Trac-In                                                 | [Paper](https://arxiv.org/abs/2002.08484)  | WIP  |
+| **Influence Method**                                    | Source                                    |                                                                               Tutorial                                                                               |
+|:--------------------------------------------------------| :---------------------------------------- |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+| Influence Functions                                     | [Paper](https://arxiv.org/abs/1703.04730)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1WlYcQNu5obhVjhonN2QYi8ybKyZJl4iY?usp=sharing)  |
+| RelatIF                                                 | [Paper](https://arxiv.org/pdf/2003.11630.pdf)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1WlYcQNu5obhVjhonN2QYi8ybKyZJl4iY?usp=sharing)  |
+| Influence Functions  (first order, groups)              | [Paper](https://arxiv.org/abs/1905.13289)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1WlYcQNu5obhVjhonN2QYi8ybKyZJl4iY?usp=sharing)  |
+| Influence Functions  (second order, groups)             | [Paper](https://arxiv.org/abs/1911.00418)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1qNvKiU3-aZWhRA0rxS6X3ebeNkoznJJe?usp=sharing)  |
+| Representer Point Selection  (L2)                       | [Paper](https://arxiv.org/abs/1811.09720)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/17W5s30LbxABbDd8hbdwYE56abyWjSC4u?usp=sharing)  |
+| Representer Point Selection  (Local Jacobian Expansion) | [Paper](https://proceedings.neurips.cc/paper/2021/file/c460dc0f18fc309ac07306a4a55d2fd6-Paper.pdf)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/14e7wwFRQJhY-huVYmJ7ri355kfLJgAPA?usp=sharing)  |
+| Trac-In                                                 | [Paper](https://arxiv.org/abs/2002.08484)  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1E94cGF46SUQXcCTNwQ4VGSjXEKm7g21c?usp=sharing)  |
 
 ## 👀 See Also
 
@@ -163,7 +163,7 @@ This project received funding from the French ”Investing for the Future – PI
 
 ## 👨‍🎓 Creators
 
-This library was first created as a research tool by [Agustin-Martin PICARD](mailto:agustin-martin.picard@irt-saintexupery.com) in the context of the DEEL project with the help of [David Vigouroux](mailto:david.vigouroux@irt-saintexupery.com) and [Thomas FEL](http://thomasfel.fr). Later on, [Lucas Hervier](https://github.com/lucashervier) joined the team to transform (at least attempt) the code base as a practical user-(almost)-friendly and efficient tool.
+This library was first created as a research tool by [Agustin Martin PICARD](mailto:agustin-martin.picard@irt-saintexupery.com) in the context of the DEEL project with the help of [David Vigouroux](mailto:david.vigouroux@irt-saintexupery.com) and [Thomas FEL](http://thomasfel.fr). Later on, [Lucas Hervier](https://github.com/lucashervier) joined the team to transform (at least attempt) the code base as a practical user-(almost)-friendly and efficient tool.
 
 ## 📝 License
 


### PR DESCRIPTION
# Quick bug fix for RPS L2

## Bug fix

This addresses a bug where a shape prevents a concatenate from creating the top-k from training set list of elements, and another one where an argmax is computed twice, making a gather operation fail when computing a top-k.

Divisions in this technique are also sometimes unstable so a small constant is added to stabilize them.

## Docs

An explanation for a parameter in the bench module is added.

The docs are also updated to contain the links to the new notebooks.
